### PR TITLE
Update ir-rescue-nix-v1.1.0.sh

### DIFF
--- a/nix/ir-rescue-nix-v1.1.0.sh
+++ b/nix/ir-rescue-nix-v1.1.0.sh
@@ -469,6 +469,11 @@ init () {
 		rconf system-distribution sys-distro "${cfg[sys-all]}" "${cfg[sys]}"
 		rconf system-info sys-info "${cfg[sys-all]}" "${cfg[sys]}"
 		rconf system-account sys-acc "${cfg[sys-all]}" "${cfg[sys]}"
+		
+		rconf network net
+		rconf network-all net-all
+		test "${cfg[net]}" = false && cfg[net-all]=false
+		rconf network-info net-info "${cfg[net-all]}" "${cfg[net]}"
 
 		rconf filesystem fs
 		rconf filesystem-all fs-all


### PR DESCRIPTION
Due to a missing area in the original script version 1.4.3, no network information was saved during execution. This was the case regardless of the configuration.